### PR TITLE
NodeJS Memory Optimizations

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/bcgov/restoration-tracker.git"
   },
   "scripts": {
-    "start": "ts-node src/app",
+    "start": "ts-node --max-old-space-size=1000 src/app",
     "clean": "gulp clean",
     "build": "gulp build",
     "start-reload": "./node_modules/.bin/nodemon src/app.ts --exec ts-node",

--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "deploy_start": "node server",
+    "deploy_start": "node --max-old-space-size=1000 server",
     "test": "react-scripts test --env=jsdom-fourteen --ci --watchAll=false --runInBand",
     "test-watch": "react-scripts test --env=jsdom-fourteen",
     "coverage": "react-scripts test --ci --coverage --testResultsProcessor jest-sonar-reporter --env=jsdom-fourteen --watchAll=false --runInBand",


### PR DESCRIPTION
Configuring both NodeJS instances (API and APP) to use a maximum of 1Gb memory. As opposed to the default 4GB.
