### PR TITLE
Nert 277 - Layer Switcher

### DIFF
--- a/app/.prettierrc
+++ b/app/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "printWidth": 80,
+  "printWidth": 100,
   "tabWidth": 2,
   "useTabs": false,
   "semi": true,

--- a/app/.prettierrc
+++ b/app/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "printWidth": 100,
+  "printWidth": 80,
   "tabWidth": 2,
   "useTabs": false,
   "semi": true,

--- a/app/src/components/map/MapContainer2.tsx
+++ b/app/src/components/map/MapContainer2.tsx
@@ -336,11 +336,14 @@ const initializeMap = (
 
 /**
  * # checkLayerVisibility
+ *
  * Loop through the layer visibility object and check the visibility
  * of the layers. It is important to make sure the map is initialized
  * along with each layer.
+ *
  * The individual layers are grouped together in a custom fashion, so
  * we need to check the visibility of each group.
+ *
  * @param layers Layer visibility object
  * @returns void
  */

--- a/app/src/components/map/MapContainer2.tsx
+++ b/app/src/components/map/MapContainer2.tsx
@@ -239,10 +239,7 @@ const initializeMap = (
     map.on('click', 'markers.polygons', (e: any) => {
       const prop = e.features![0].properties;
 
-      new Popup()
-        .setLngLat(e.lngLat)
-        .setHTML(`<div>${prop.name}</div>`)
-        .addTo(map);
+      new Popup().setLngLat(e.lngLat).setHTML(`<div>${prop.name}</div>`).addTo(map);
     });
     map.on('mousemove', 'markers.polygons', () => {
       map.getCanvas().style.cursor = 'pointer';
@@ -255,10 +252,7 @@ const initializeMap = (
     map.on('click', 'markers.lines', (e: any) => {
       const prop = e.features![0].properties;
 
-      new Popup()
-        .setLngLat(e.lngLat)
-        .setHTML(`<div>${prop.name}</div>`)
-        .addTo(map);
+      new Popup().setLngLat(e.lngLat).setHTML(`<div>${prop.name}</div>`).addTo(map);
     });
     map.on('mousemove', 'markers.lines', () => {
       map.getCanvas().style.cursor = 'pointer';
@@ -271,10 +265,7 @@ const initializeMap = (
     map.on('click', 'markers.points', (e: any) => {
       const prop = e.features![0].properties;
 
-      new Popup()
-        .setLngLat(e.lngLat)
-        .setHTML(`<div>${prop.name}</div>`)
-        .addTo(map);
+      new Popup().setLngLat(e.lngLat).setHTML(`<div>${prop.name}</div>`).addTo(map);
     });
     map.on('mousemove', 'markers.points', () => {
       map.getCanvas().style.cursor = 'pointer';
@@ -351,11 +342,7 @@ const checkLayerVisibility = (layers: any) => {
   Object.keys(layers).forEach((layer) => {
     // The boundary layer is simple enough.
     if (layer === 'boundary' && map.getLayer('ne_boundary')) {
-      map.setLayoutProperty(
-        'ne_boundary',
-        'visibility',
-        layers[layer][0] ? 'visible' : 'none'
-      );
+      map.setLayoutProperty('ne_boundary', 'visibility', layers[layer][0] ? 'visible' : 'none');
     }
 
     // Wells is a group of three different point layers
@@ -412,16 +399,8 @@ const checkLayerVisibility = (layers: any) => {
         'visibility',
         layers[layer][0] ? 'visible' : 'none'
       );
-      map.setLayoutProperty(
-        'markers.lines',
-        'visibility',
-        layers[layer][0] ? 'visible' : 'none'
-      );
-      map.setLayoutProperty(
-        'markers.points',
-        'visibility',
-        layers[layer][0] ? 'visible' : 'none'
-      );
+      map.setLayoutProperty('markers.lines', 'visibility', layers[layer][0] ? 'visible' : 'none');
+      map.setLayoutProperty('markers.points', 'visibility', layers[layer][0] ? 'visible' : 'none');
     }
   });
 };

--- a/app/src/components/map/MapContainer2.tsx
+++ b/app/src/components/map/MapContainer2.tsx
@@ -132,7 +132,6 @@ const initializeMap = (
   if (markers.length === 0) return;
 
   const { boundary, wells, projects, wildlife, indigenous } = layerVisibility;
-  console.log(boundary, wells, projects, wildlife, indigenous);
 
   const markerGeoJSON = convertToGeoJSON(markers);
 
@@ -335,6 +334,97 @@ const initializeMap = (
   });
 };
 
+/**
+ * # checkLayerVisibility
+ * Loop through the layer visibility object and check the visibility
+ * of the layers. It is important to make sure the map is initialized
+ * along with each layer.
+ * The individual layers are grouped together in a custom fashion, so
+ * we need to check the visibility of each group.
+ * @param layers Layer visibility object
+ * @returns void
+ */
+const checkLayerVisibility = (layers: any) => {
+  if (!map) return; // Exist if map is not initialized
+
+  Object.keys(layers).forEach((layer) => {
+    // The boundary layer is simple enough.
+    if (layer === 'boundary' && map.getLayer('ne_boundary')) {
+      map.setLayoutProperty(
+        'ne_boundary',
+        'visibility',
+        layers[layer][0] ? 'visible' : 'none'
+      );
+    }
+
+    // Wells is a group of three different point layers
+    if (
+      layer === 'wells' &&
+      map.getLayer('orphanedWellsLayer') &&
+      map.getLayer('orphanedActivitiesLayer') &&
+      map.getLayer('surfaceStateLayer')
+    ) {
+      map.setLayoutProperty(
+        'orphanedWellsLayer',
+        'visibility',
+        layers[layer][0] ? 'visible' : 'none'
+      );
+      map.setLayoutProperty(
+        'orphanedActivitiesLayer',
+        'visibility',
+        layers[layer][0] ? 'visible' : 'none'
+      );
+      map.setLayoutProperty(
+        'surfaceStateLayer',
+        'visibility',
+        layers[layer][0] ? 'visible' : 'none'
+      );
+    }
+
+    // This is a concatenated (server side) WMS layer from the BCGW
+    if (layer === 'wildlife' && map.getLayer('wms-wildlife-areas')) {
+      map.setLayoutProperty(
+        'wms-wildlife-areas',
+        'visibility',
+        layers[layer][0] ? 'visible' : 'none'
+      );
+    }
+
+    // This will be extended to include indigenous community point locations
+    if (layer === 'indigenous' && map.getLayer('wms-indigenous-areas')) {
+      map.setLayoutProperty(
+        'wms-indigenous-areas',
+        'visibility',
+        layers[layer][0] ? 'visible' : 'none'
+      );
+    }
+
+    // Projects and plans can have three separate geometry types
+    if (
+      layer === 'projects' &&
+      map.getLayer('markers.polygons') &&
+      map.getLayer('markers.lines') &&
+      map.getLayer('markers.points')
+    ) {
+      map.setLayoutProperty(
+        'markers.polygons',
+        'visibility',
+        layers[layer][0] ? 'visible' : 'none'
+      );
+      map.setLayoutProperty(
+        'markers.lines',
+        'visibility',
+        layers[layer][0] ? 'visible' : 'none'
+      );
+      map.setLayoutProperty(
+        'markers.points',
+        'visibility',
+        layers[layer][0] ? 'visible' : 'none'
+      );
+    }
+  });
+};
+
 const MapContainer: React.FC<IMapContainerProps> = (props) => {
   const { mapId, center, zoom, markers, layerVisibility } = props;
 
@@ -345,10 +435,7 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
 
   // Listen to layer changes
   useEffect(() => {
-    // TODO: Implement layer visibility changes
-    console.log('layers changed');
-    console.log('map', map);
-    console.log('layerVisibility', layerVisibility);
+    checkLayerVisibility(layerVisibility);
   }, [layerVisibility]);
 
   return <div id={mapId} style={pageStyle}></div>;

--- a/app/src/components/map/MapContainer2.tsx
+++ b/app/src/components/map/MapContainer2.tsx
@@ -174,7 +174,7 @@ const initializeMap = (mapId: string, center: any, zoom: number, markers: any) =
       }
     });
 
-    /* Add the markers */
+    /*****************Project/Plans********************/
     map.addSource('markers', {
       type: 'geojson',
       data: markerGeoJSON as FeatureCollection
@@ -247,6 +247,7 @@ const initializeMap = (mapId: string, center: any, zoom: number, markers: any) =
     map.on('mouseleave', 'markers.points', () => {
       map.getCanvas().style.cursor = '';
     });
+    /**************************************************/
 
     /* Protected Areas as WMS layers from the BCGW */
     map.addSource('wildlife-areas', {

--- a/app/src/components/map/MapContainer2.tsx
+++ b/app/src/components/map/MapContainer2.tsx
@@ -16,6 +16,7 @@ export interface IMapContainerProps {
   center?: any;
   zoom?: any;
   markers?: any;
+  layerVisibility?: any;
 }
 
 const MAPTILER_API_KEY = process.env.REACT_APP_MAPTILER_API_KEY;
@@ -29,7 +30,7 @@ const pageStyle = {
  * This function draws the wells on the map
  * @param map - the map object
  */
-const drawWells = (map: maplibre.Map) => {
+const drawWells = (map: maplibre.Map, wells: any) => {
   /* The following are the URLs to the geojson data */
   const orphanedWellsURL =
     'https://geoweb-ags.bc-er.ca/arcgis/rest/services/OPERATIONAL/ORPHAN_WELL_PT/FeatureServer/0/query?outFields=*&where=1%3D1&f=geojson';
@@ -47,6 +48,9 @@ const drawWells = (map: maplibre.Map) => {
     id: 'orphanedWellsLayer',
     type: 'circle',
     source: 'orphanedWells',
+    layout: {
+      visibility: wells[0] ? 'visible' : 'none'
+    },
     paint: {
       'circle-radius': 5,
       'circle-color': 'red'
@@ -62,6 +66,9 @@ const drawWells = (map: maplibre.Map) => {
     id: 'orphanedActivitiesLayer',
     type: 'circle',
     source: 'orphanedActivities',
+    layout: {
+      visibility: wells[0] ? 'visible' : 'none'
+    },
     paint: {
       'circle-radius': 5,
       'circle-color': 'blue'
@@ -77,6 +84,9 @@ const drawWells = (map: maplibre.Map) => {
     id: 'surfaceStateLayer',
     type: 'circle',
     source: 'surfaceState',
+    layout: {
+      visibility: wells[0] ? 'visible' : 'none'
+    },
     paint: {
       'circle-radius': 5,
       'circle-color': 'green'
@@ -112,8 +122,17 @@ const convertToGeoJSON = (features: any) => {
 
 let map: maplibre.Map;
 
-const initializeMap = (mapId: string, center: any, zoom: number, markers: any) => {
+const initializeMap = (
+  mapId: string,
+  center: any,
+  zoom: number,
+  markers: any,
+  layerVisibility?: any
+) => {
   if (markers.length === 0) return;
+
+  const { boundary, wells, projects, wildlife, indigenous } = layerVisibility;
+  console.log(boundary, wells, projects, wildlife, indigenous);
 
   const markerGeoJSON = convertToGeoJSON(markers);
 
@@ -166,7 +185,8 @@ const initializeMap = (mapId: string, center: any, zoom: number, markers: any) =
       source: 'ne_boundary',
       layout: {
         'line-join': 'round',
-        'line-cap': 'round'
+        'line-cap': 'round',
+        visibility: boundary[0] ? 'visible' : 'none'
       },
       paint: {
         'line-color': 'yellow',
@@ -184,6 +204,9 @@ const initializeMap = (mapId: string, center: any, zoom: number, markers: any) =
       type: 'fill',
       source: 'markers',
       filter: ['==', '$type', 'Polygon'],
+      layout: {
+        visibility: projects[0] ? 'visible' : 'none'
+      },
       paint: {
         'fill-color': 'yellow',
         'fill-opacity': 0.4
@@ -194,6 +217,9 @@ const initializeMap = (mapId: string, center: any, zoom: number, markers: any) =
       type: 'line',
       source: 'markers',
       filter: ['==', '$type', 'LineString'],
+      layout: {
+        visibility: projects[0] ? 'visible' : 'none'
+      },
       paint: {
         'line-color': 'yellow',
         'line-width': 3
@@ -204,6 +230,9 @@ const initializeMap = (mapId: string, center: any, zoom: number, markers: any) =
       type: 'circle',
       source: 'markers',
       filter: ['==', '$type', 'Point'],
+      layout: {
+        visibility: projects[0] ? 'visible' : 'none'
+      },
       paint: {
         'circle-color': 'yellow',
         'circle-radius': 5
@@ -213,7 +242,10 @@ const initializeMap = (mapId: string, center: any, zoom: number, markers: any) =
     map.on('click', 'markers.polygons', (e: any) => {
       const prop = e.features![0].properties;
 
-      new Popup().setLngLat(e.lngLat).setHTML(`<div>${prop.name}</div>`).addTo(map);
+      new Popup()
+        .setLngLat(e.lngLat)
+        .setHTML(`<div>${prop.name}</div>`)
+        .addTo(map);
     });
     map.on('mousemove', 'markers.polygons', () => {
       map.getCanvas().style.cursor = 'pointer';
@@ -226,7 +258,10 @@ const initializeMap = (mapId: string, center: any, zoom: number, markers: any) =
     map.on('click', 'markers.lines', (e: any) => {
       const prop = e.features![0].properties;
 
-      new Popup().setLngLat(e.lngLat).setHTML(`<div>${prop.name}</div>`).addTo(map);
+      new Popup()
+        .setLngLat(e.lngLat)
+        .setHTML(`<div>${prop.name}</div>`)
+        .addTo(map);
     });
     map.on('mousemove', 'markers.lines', () => {
       map.getCanvas().style.cursor = 'pointer';
@@ -239,7 +274,10 @@ const initializeMap = (mapId: string, center: any, zoom: number, markers: any) =
     map.on('click', 'markers.points', (e: any) => {
       const prop = e.features![0].properties;
 
-      new Popup().setLngLat(e.lngLat).setHTML(`<div>${prop.name}</div>`).addTo(map);
+      new Popup()
+        .setLngLat(e.lngLat)
+        .setHTML(`<div>${prop.name}</div>`)
+        .addTo(map);
     });
     map.on('mousemove', 'markers.points', () => {
       map.getCanvas().style.cursor = 'pointer';
@@ -262,6 +300,9 @@ const initializeMap = (mapId: string, center: any, zoom: number, markers: any) =
       id: 'wms-wildlife-areas',
       type: 'raster',
       source: 'wildlife-areas',
+      layout: {
+        visibility: wildlife[0] ? 'visible' : 'none'
+      },
       paint: {
         'raster-opacity': 0.5
       }
@@ -282,21 +323,33 @@ const initializeMap = (mapId: string, center: any, zoom: number, markers: any) =
       id: 'wms-indigenous-areas',
       type: 'raster',
       source: 'indigenous-areas',
+      layout: {
+        visibility: indigenous[0] ? 'visible' : 'none'
+      },
       paint: {
         'raster-opacity': 0.5
       }
     });
     // Add the well layers
-    drawWells(map);
+    drawWells(map, wells);
   });
 };
 
 const MapContainer: React.FC<IMapContainerProps> = (props) => {
-  const { mapId, center, zoom, markers } = props;
+  const { mapId, center, zoom, markers, layerVisibility } = props;
 
+  // Update the map if the markers change
   useEffect(() => {
-    initializeMap(mapId, center, zoom, markers);
-  });
+    initializeMap(mapId, center, zoom, markers, layerVisibility);
+  }, [markers]);
+
+  // Listen to layer changes
+  useEffect(() => {
+    // TODO: Implement layer visibility changes
+    console.log('layers changed');
+    console.log('map', map);
+    console.log('layerVisibility', layerVisibility);
+  }, [layerVisibility]);
 
   return <div id={mapId} style={pageStyle}></div>;
 };

--- a/app/src/components/map/MapContainer2.tsx
+++ b/app/src/components/map/MapContainer2.tsx
@@ -129,8 +129,6 @@ const initializeMap = (
   markers: any,
   layerVisibility?: any
 ) => {
-  if (markers.length === 0) return;
-
   const { boundary, wells, projects, wildlife, indigenous } = layerVisibility;
 
   const markerGeoJSON = convertToGeoJSON(markers);

--- a/app/src/components/map/components/LayerSwitcher.tsx
+++ b/app/src/components/map/components/LayerSwitcher.tsx
@@ -42,7 +42,7 @@ const LayerSwitcher = (props: ILayerSwitcherProps) => {
         />
         <FormControlLabel
           control={<Checkbox checked={projects[0]} onClick={() => projects[1](!projects[0])} />}
-          label="Projects"
+          label="Projects & Plans"
         />
         <FormControlLabel
           control={<Checkbox checked={wildlife[0]} onClick={() => wildlife[1](!wildlife[0])} />}

--- a/app/src/components/map/components/LayerSwitcher.tsx
+++ b/app/src/components/map/components/LayerSwitcher.tsx
@@ -1,0 +1,83 @@
+/**
+ * Layer Switcher Component
+ * Turn layers on and off
+ */
+import { Box, Checkbox, FormControlLabel, FormGroup } from '@mui/material';
+import React from 'react';
+
+export interface ILayerSwitcherProps {
+  layerVisibility: {
+    boundary: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
+    wells: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
+    projects: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
+    wildlife: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
+    indigenous: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
+  };
+}
+
+const style = {
+  position: 'absolute',
+  bottom: '90px',
+  left: '20px',
+  zIndex: 1000,
+  padding: '10px',
+  backgroundColor: 'white',
+  borderRadius: '5px',
+  boxShadow: '0 0 10px rgba(0,0,0,0.5)'
+};
+
+const LayerSwitcher = (props: ILayerSwitcherProps) => {
+  const { boundary, wells, projects, wildlife, indigenous } =
+    props.layerVisibility;
+  return (
+    <Box sx={style}>
+      Layer Switcher
+      <FormGroup>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={boundary[0]}
+              onClick={() => boundary[1](!boundary[0])}
+            />
+          }
+          label="Project Boundary"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox checked={wells[0]} onClick={() => wells[1](!wells[0])} />
+          }
+          label="Wells"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={projects[0]}
+              onClick={() => projects[1](!projects[0])}
+            />
+          }
+          label="Projects"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={wildlife[0]}
+              onClick={() => wildlife[1](!wildlife[0])}
+            />
+          }
+          label="Wildlife"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={indigenous[0]}
+              onClick={() => indigenous[1](!indigenous[0])}
+            />
+          }
+          label="Indigenous"
+        />
+      </FormGroup>
+    </Box>
+  );
+};
+
+export default LayerSwitcher;

--- a/app/src/components/map/components/LayerSwitcher.tsx
+++ b/app/src/components/map/components/LayerSwitcher.tsx
@@ -27,51 +27,30 @@ const style = {
 };
 
 const LayerSwitcher = (props: ILayerSwitcherProps) => {
-  const { boundary, wells, projects, wildlife, indigenous } =
-    props.layerVisibility;
+  const { boundary, wells, projects, wildlife, indigenous } = props.layerVisibility;
   return (
     <Box sx={style}>
       Context Layers
       <FormGroup>
         <FormControlLabel
-          control={
-            <Checkbox
-              checked={boundary[0]}
-              onClick={() => boundary[1](!boundary[0])}
-            />
-          }
+          control={<Checkbox checked={boundary[0]} onClick={() => boundary[1](!boundary[0])} />}
           label="Project Boundary"
         />
         <FormControlLabel
-          control={
-            <Checkbox checked={wells[0]} onClick={() => wells[1](!wells[0])} />
-          }
+          control={<Checkbox checked={wells[0]} onClick={() => wells[1](!wells[0])} />}
           label="Wells"
         />
         <FormControlLabel
-          control={
-            <Checkbox
-              checked={projects[0]}
-              onClick={() => projects[1](!projects[0])}
-            />
-          }
+          control={<Checkbox checked={projects[0]} onClick={() => projects[1](!projects[0])} />}
           label="Projects"
         />
         <FormControlLabel
-          control={
-            <Checkbox
-              checked={wildlife[0]}
-              onClick={() => wildlife[1](!wildlife[0])}
-            />
-          }
+          control={<Checkbox checked={wildlife[0]} onClick={() => wildlife[1](!wildlife[0])} />}
           label="Wildlife"
         />
         <FormControlLabel
           control={
-            <Checkbox
-              checked={indigenous[0]}
-              onClick={() => indigenous[1](!indigenous[0])}
-            />
+            <Checkbox checked={indigenous[0]} onClick={() => indigenous[1](!indigenous[0])} />
           }
           label="Indigenous"
         />

--- a/app/src/components/map/components/LayerSwitcher.tsx
+++ b/app/src/components/map/components/LayerSwitcher.tsx
@@ -31,7 +31,7 @@ const LayerSwitcher = (props: ILayerSwitcherProps) => {
     props.layerVisibility;
   return (
     <Box sx={style}>
-      Layer Switcher
+      Context Layers
       <FormGroup>
         <FormControlLabel
           control={

--- a/app/src/features/search/SearchPage.tsx
+++ b/app/src/features/search/SearchPage.tsx
@@ -1,8 +1,8 @@
 import Box from '@mui/material/Box';
 import centroid from '@turf/centroid';
 import { IErrorDialogProps } from 'components/dialog/ErrorDialog';
+import LayerSwitcher from 'components/map/components/LayerSwitcher';
 import { IMarker } from 'components/map/components/MarkerCluster';
-// import MapContainer from 'components/map/MapContainer';
 import MapContainer from 'components/map/MapContainer2';
 import { SearchFeaturePopup } from 'components/map/SearchFeaturePopup';
 import { AuthStateContext } from 'contexts/authStateContext';
@@ -58,11 +58,14 @@ const SearchPage: React.FC = () => {
       const clusteredPointGeometries: IMarker[] = [];
 
       response.forEach((result: any) => {
-        const feature = generateValidGeometryCollection(result.geometry, result.id)
-          .geometryCollection[0];
+        const feature = generateValidGeometryCollection(
+          result.geometry,
+          result.id
+        ).geometryCollection[0];
 
         clusteredPointGeometries.push({
-          position: centroid(feature as any).geometry.coordinates as LatLngTuple,
+          position: centroid(feature as any).geometry
+            .coordinates as LatLngTuple,
           popup: <SearchFeaturePopup featureData={result} />
         });
       });
@@ -77,7 +80,12 @@ const SearchPage: React.FC = () => {
         dialogErrorDetails: apiError?.errors
       });
     }
-  }, [restorationApi.search, restorationApi.public.search, showFilterErrorDialog, keycloakWrapper]);
+  }, [
+    restorationApi.search,
+    restorationApi.public.search,
+    showFilterErrorDialog,
+    keycloakWrapper
+  ]);
 
   useEffect(() => {
     if (performSearch) {
@@ -86,11 +94,35 @@ const SearchPage: React.FC = () => {
   }, [performSearch, getSearchResults]);
 
   /**
+   * Reactive state to share between the layer picker and the map
+   */
+  const boundary = useState<boolean>(true);
+  const wells = useState<boolean>(false);
+  const projects = useState<boolean>(true);
+  const wildlife = useState<boolean>(false);
+  const indigenous = useState<boolean>(false);
+
+  const layerVisibility = {
+    boundary,
+    wells,
+    projects,
+    wildlife,
+    indigenous
+  };
+
+  /**
    * Displays search results visualized on a map spatially.
    */
   return (
     <Box sx={{ height: '100%' }}>
-      <MapContainer mapId="search_boundary_map" center={[-124, 57]} zoom={6} markers={geometries} />
+      <MapContainer
+        mapId="search_boundary_map"
+        center={[-124, 57]}
+        zoom={6}
+        markers={geometries}
+        layerVisibility={layerVisibility}
+      />
+      <LayerSwitcher layerVisibility={layerVisibility} />
     </Box>
   );
 };

--- a/app/src/features/search/SearchPage.tsx
+++ b/app/src/features/search/SearchPage.tsx
@@ -58,14 +58,11 @@ const SearchPage: React.FC = () => {
       const clusteredPointGeometries: IMarker[] = [];
 
       response.forEach((result: any) => {
-        const feature = generateValidGeometryCollection(
-          result.geometry,
-          result.id
-        ).geometryCollection[0];
+        const feature = generateValidGeometryCollection(result.geometry, result.id)
+          .geometryCollection[0];
 
         clusteredPointGeometries.push({
-          position: centroid(feature as any).geometry
-            .coordinates as LatLngTuple,
+          position: centroid(feature as any).geometry.coordinates as LatLngTuple,
           popup: <SearchFeaturePopup featureData={result} />
         });
       });
@@ -80,12 +77,7 @@ const SearchPage: React.FC = () => {
         dialogErrorDetails: apiError?.errors
       });
     }
-  }, [
-    restorationApi.search,
-    restorationApi.public.search,
-    showFilterErrorDialog,
-    keycloakWrapper
-  ]);
+  }, [restorationApi.search, restorationApi.public.search, showFilterErrorDialog, keycloakWrapper]);
 
   useEffect(() => {
     if (performSearch) {


### PR DESCRIPTION
# New Layer Switcher
- Layer switching component that can be reused throughout the app
- Layer switching component state isolated within the parent component/page
- Layer switching events tied into React hooks
- Minimal styling

![Screenshot from 2024-04-08 10-36-07](https://github.com/bcgov/nert-restoration-tracker/assets/479074/1fdba654-8136-4c54-a8ae-fd6a69a70fb4)
