### PR TITLE
Nert 257 - Map control for layer switcher to match Leaflet control.

### DIFF
--- a/app/src/components/map/components/LayerSwitcher.tsx
+++ b/app/src/components/map/components/LayerSwitcher.tsx
@@ -19,8 +19,8 @@ export interface ILayerSwitcherProps {
 
 const switcherStyle = {
   position: 'absolute',
-  bottom: '90px',
-  left: '20px',
+  bottom: '120px',
+  right: '10px',
   zIndex: 1000,
   padding: '10px',
   backgroundColor: 'white',
@@ -35,8 +35,8 @@ const switcherCloseStyle = {
 
 const buttonStyle = {
   position: 'absolute',
-  bottom: '90px',
-  left: '20px',
+  bottom: '120px',
+  right: '10px',
   zIndex: 1000,
   backgroundColor: 'white',
   borderRadius: '5px',
@@ -53,19 +53,19 @@ const LayerSwitcher = (props: ILayerSwitcherProps) => {
   return (
     <div>
       {switcherOpen ? (
-        <Box sx={buttonStyle}>
+        <Box title="Open Layer Picker" sx={buttonStyle}>
           <IconButton onClick={toggleLayerswitcher}>
             <LayersIcon />
           </IconButton>
         </Box>
       ) : (
         <Box sx={switcherStyle}>
-          <Box sx={switcherCloseStyle}>
+          <Box title="Close Layer Picker" sx={switcherCloseStyle}>
             <IconButton onClick={toggleLayerswitcher}>
               <CloseIcon />
             </IconButton>
           </Box>
-          Context Layers
+          <b>Context Layers</b>
           <FormGroup>
             <FormControlLabel
               control={<Checkbox checked={boundary[0]} onClick={() => boundary[1](!boundary[0])} />}

--- a/app/src/components/map/components/LayerSwitcher.tsx
+++ b/app/src/components/map/components/LayerSwitcher.tsx
@@ -2,8 +2,10 @@
  * Layer Switcher Component
  * Turn layers on and off
  */
-import { Box, Checkbox, FormControlLabel, FormGroup } from '@mui/material';
-import React from 'react';
+import CloseIcon from '@mui/icons-material/Close';
+import LayersIcon from '@mui/icons-material/Layers';
+import { Box, Checkbox, FormControlLabel, FormGroup, IconButton } from '@mui/material';
+import React, { useState } from 'react';
 
 export interface ILayerSwitcherProps {
   layerVisibility: {
@@ -15,7 +17,7 @@ export interface ILayerSwitcherProps {
   };
 }
 
-const style = {
+const switcherStyle = {
   position: 'absolute',
   bottom: '90px',
   left: '20px',
@@ -25,37 +27,72 @@ const style = {
   borderRadius: '5px',
   boxShadow: '0 0 10px rgba(0,0,0,0.5)'
 };
+const switcherCloseStyle = {
+  position: 'absolute',
+  right: '2px',
+  top: '2px'
+};
+
+const buttonStyle = {
+  position: 'absolute',
+  bottom: '90px',
+  left: '20px',
+  zIndex: 1000,
+  backgroundColor: 'white',
+  borderRadius: '5px',
+  boxShadow: '0 0 10px rgba(0,0,0,0.5)'
+};
 
 const LayerSwitcher = (props: ILayerSwitcherProps) => {
   const { boundary, wells, projects, wildlife, indigenous } = props.layerVisibility;
+
+  const toggleLayerswitcher = () => setSwitcherOpen(!switcherOpen);
+
+  const [switcherOpen, setSwitcherOpen] = useState(false);
+
   return (
-    <Box sx={style}>
-      Context Layers
-      <FormGroup>
-        <FormControlLabel
-          control={<Checkbox checked={boundary[0]} onClick={() => boundary[1](!boundary[0])} />}
-          label="Project Boundary"
-        />
-        <FormControlLabel
-          control={<Checkbox checked={wells[0]} onClick={() => wells[1](!wells[0])} />}
-          label="Wells"
-        />
-        <FormControlLabel
-          control={<Checkbox checked={projects[0]} onClick={() => projects[1](!projects[0])} />}
-          label="Projects & Plans"
-        />
-        <FormControlLabel
-          control={<Checkbox checked={wildlife[0]} onClick={() => wildlife[1](!wildlife[0])} />}
-          label="Wildlife"
-        />
-        <FormControlLabel
-          control={
-            <Checkbox checked={indigenous[0]} onClick={() => indigenous[1](!indigenous[0])} />
-          }
-          label="Indigenous"
-        />
-      </FormGroup>
-    </Box>
+    <div>
+      {switcherOpen ? (
+        <Box sx={buttonStyle}>
+          <IconButton onClick={toggleLayerswitcher}>
+            <LayersIcon />
+          </IconButton>
+        </Box>
+      ) : (
+        <Box sx={switcherStyle}>
+          <Box sx={switcherCloseStyle}>
+            <IconButton onClick={toggleLayerswitcher}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
+          Context Layers
+          <FormGroup>
+            <FormControlLabel
+              control={<Checkbox checked={boundary[0]} onClick={() => boundary[1](!boundary[0])} />}
+              label="Project Boundary"
+            />
+            <FormControlLabel
+              control={<Checkbox checked={wells[0]} onClick={() => wells[1](!wells[0])} />}
+              label="Wells"
+            />
+            <FormControlLabel
+              control={<Checkbox checked={projects[0]} onClick={() => projects[1](!projects[0])} />}
+              label="Projects & Plans"
+            />
+            <FormControlLabel
+              control={<Checkbox checked={wildlife[0]} onClick={() => wildlife[1](!wildlife[0])} />}
+              label="Wildlife"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox checked={indigenous[0]} onClick={() => indigenous[1](!indigenous[0])} />
+              }
+              label="Indigenous"
+            />
+          </FormGroup>
+        </Box>
+      )}
+    </div>
   );
 };
 


### PR DESCRIPTION
- Button in the bottom right of the map to open the layer picker.
- Made to match what we previously had in leaflet.
- Close button has been added to the layer picker box
- Currently defaulting to open

![Screenshot from 2024-04-10 10-09-12](https://github.com/bcgov/nert-restoration-tracker/assets/479074/e5820a12-58ee-4f80-bb9a-57229281220f)
![Screenshot from 2024-04-10 10-09-40](https://github.com/bcgov/nert-restoration-tracker/assets/479074/b916b9cc-7dfc-481d-89b9-bebd82854b00)
