### PR TITLE
Nert 295 - Hover Project/Plans

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -38,7 +38,7 @@
         "leaflet-fullscreen": "~1.0.2",
         "leaflet.locatecontrol": "^0.76.1",
         "lodash-es": "~4.17.21",
-        "maplibre-gl": "^4.1.2",
+        "maplibre-gl": "^4.1.3",
         "qs": "~6.11.2",
         "react": "~18.2.0",
         "react-collapsed": "^4.1.2",
@@ -16562,9 +16562,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.1.2.tgz",
-      "integrity": "sha512-98T+3BesL4w/N39q/rgs9q6HzHLG6pgbS9UaTqg6fMISfzy2WGKokjK205ENFDDmEljj54/LTfdXgqg2XfYU4A==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.1.3.tgz",
+      "integrity": "sha512-nMy5h0kzq9Z66C6AIb3p2BvLIVHz75dGGQow22x+h9/VOihr0IPQI26ylAi6lHqvEy2VqjiRmKAMlFwt0xFKfQ==",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",

--- a/app/package.json
+++ b/app/package.json
@@ -54,7 +54,7 @@
     "leaflet-fullscreen": "~1.0.2",
     "leaflet.locatecontrol": "^0.76.1",
     "lodash-es": "~4.17.21",
-    "maplibre-gl": "^4.1.2",
+    "maplibre-gl": "^4.1.3",
     "qs": "~6.11.2",
     "react": "~18.2.0",
     "react-collapsed": "^4.1.2",

--- a/app/src/components/map/mapContainer2Style.css
+++ b/app/src/components/map/mapContainer2Style.css
@@ -18,3 +18,31 @@
   color: black;
   border-radius: 50%;
 }
+
+#tooltip {
+  position: none;
+  opacity: 0;
+}
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+#tooltip.visible {
+  position: absolute;
+  color: white;
+  font-size: 1rem;
+  font-weight: bold;
+  pointer-events: none;
+  z-index: 101;
+  animation: fadeIn 0.5s;
+  opacity: 1;
+  text-shadow: 0px 0px 3px black;
+}


### PR DESCRIPTION
- Hover the mouse over the icon displays the name.
- Opacity transition in on mouse enter
- Instant removal on mouse out
- Slight black halo to allow for visibility on both dark and light basemaps.
- Updated Maplibre to incorporate the latest bug fixes.

<hr>

![Untitled](https://github.com/bcgov/nert-restoration-tracker/assets/479074/51aa3c8b-02f5-4684-89bb-6d5ae6350add)
