### PR TITLE
Nert 272 - Styling for Well Sites and Well Activities

### DIFF
--- a/app/src/components/map/MapContainer2.tsx
+++ b/app/src/components/map/MapContainer2.tsx
@@ -33,25 +33,16 @@ const pageStyle = {
  */
 const drawWells = (map: maplibre.Map, wells: any) => {
   /* The following are the URLs to the geojson data */
-  // TODO: These will be replaced with new file logic
-  // Grab the correct data from here https://geoweb-ags.bc-er.ca/arcgis/rest/services
-  const orphanedWellsURL =
-    'https://geoweb-ags.bc-er.ca/arcgis/rest/services/OPERATIONAL/ORPHAN_WELL_PT/FeatureServer/0/query?outFields=*&where=1%3D1&f=geojson';
+  const orphanedSitesURL =
+    'https://geoweb-ags.bc-er.ca/arcgis/rest/services/OPERATIONAL/ORPHAN_SITE_PT/MapServer/0/query?outFields=*&where=1%3D1&f=geojson';
   const orphanedActivitiesURL =
     'https://geoweb-ags.bc-er.ca/arcgis/rest/services/OPERATIONAL/ORPHAN_ACTIVITY_PT/FeatureServer/0/query?outFields=*&where=1%3D1&f=geojson';
   const surfaceStateURL =
     'https://geoweb-ags.bc-er.ca/arcgis/rest/services/PASR/PASR_WELL_SURFACE_STATE_PT/MapServer/0/query?outFields=*&where=1%3D1&f=geojson';
 
-  // Orphaned wells - These is called "sites" on the BCER site
-  // XXX: The following will be replaced with new file logic
-  // ABAN, ABNZ, CANC, INAC, WAG
-  const assessedStyle = ['==', ['get', 'WELL_STATUS'], 'ABAN'];
-  const inactiveStyle = ['==', ['get', 'WELL_STATUS'], 'INAC'];
-  const decommissionedStyle = ['==', ['get', 'WELL_STATUS'], 'DECO'];
-  const reclaimedStyle = ['==', ['get', 'WELL_STATUS'], 'CANC'];
   map.addSource('orphanedWells', {
     type: 'geojson',
-    data: orphanedWellsURL
+    data: orphanedSitesURL
   });
   map.addLayer({
     id: 'orphanedWellsLayer',
@@ -61,17 +52,21 @@ const drawWells = (map: maplibre.Map, wells: any) => {
       visibility: wells[0] ? 'visible' : 'none'
     },
     paint: {
-      'circle-radius': 5,
+      'circle-radius': 7,
+      'circle-stroke-color': 'black',
+      'circle-stroke-width': 1,
+      'circle-stroke-opacity': 0.5,
       'circle-color': [
-        'case',
-        assessedStyle,
-        'salmon',
-        inactiveStyle,
-        'gray',
-        decommissionedStyle,
-        'blue',
-        reclaimedStyle,
-        'green',
+        'match',
+        ['get', 'SITE_STATUS'],
+        'Assessed',
+        '#f0933e',
+        'Inactive',
+        '#999999',
+        'Decommissioned',
+        '#7fb2f9',
+        'Reclaimed',
+        '#adc64f',
         'black'
       ]
     }

--- a/app/src/components/map/MapContainer2.tsx
+++ b/app/src/components/map/MapContainer2.tsx
@@ -330,7 +330,7 @@ const initializeMap = (
         '"margin-top: 1rem; font-size: 1.2em; font-weight: bold; background: #003366; cursor: pointer; border-radius: 5px; color: white; padding: 7px 20px; border: none; text-align: center; text-decoration: none; display: inline-block; font-family: Arial, sans-serif;"';
       return `
         <div style=${divStyle}>
-          <div>Project Name: <b>${name}</b></div>
+          <div>${isProject ? 'Project' : 'Plan'} Name: <b>${name}</b></div>
           <div class="view-btn">
             <a href="/${isProject ? 'projects' : 'plans'}/${id}" >
               <button style=${buttonStyle} title="Take me to the details page">View Project Details</button>
@@ -361,7 +361,7 @@ const initializeMap = (
 
       // TBD: Currently the /plans route is not available
       // const html = makePopup(prop.name, prop.id, false);
-      const html = makePopup(prop.name, prop.id, true);
+      const html = makePopup(prop.name, prop.id, false);
 
       // @ts-ignore
       new Popup({ offset: { bottom: [0, -14] } }).setLngLat(e.lngLat).setHTML(html).addTo(map);

--- a/app/src/components/map/MapContainer2.tsx
+++ b/app/src/components/map/MapContainer2.tsx
@@ -33,6 +33,8 @@ const pageStyle = {
  */
 const drawWells = (map: maplibre.Map, wells: any) => {
   /* The following are the URLs to the geojson data */
+  // TODO: These will be replaced with new file logic
+  // Grab the correct data from here https://geoweb-ags.bc-er.ca/arcgis/rest/services
   const orphanedWellsURL =
     'https://geoweb-ags.bc-er.ca/arcgis/rest/services/OPERATIONAL/ORPHAN_WELL_PT/FeatureServer/0/query?outFields=*&where=1%3D1&f=geojson';
   const orphanedActivitiesURL =
@@ -40,7 +42,13 @@ const drawWells = (map: maplibre.Map, wells: any) => {
   const surfaceStateURL =
     'https://geoweb-ags.bc-er.ca/arcgis/rest/services/PASR/PASR_WELL_SURFACE_STATE_PT/MapServer/0/query?outFields=*&where=1%3D1&f=geojson';
 
-  // Orphaned wells
+  // Orphaned wells - These is called "sites" on the BCER site
+  // XXX: The following will be replaced with new file logic
+  // ABAN, ABNZ, CANC, INAC, WAG
+  const assessedStyle = ['==', ['get', 'WELL_STATUS'], 'ABAN'];
+  const inactiveStyle = ['==', ['get', 'WELL_STATUS'], 'INAC'];
+  const decommissionedStyle = ['==', ['get', 'WELL_STATUS'], 'DECO'];
+  const reclaimedStyle = ['==', ['get', 'WELL_STATUS'], 'CANC'];
   map.addSource('orphanedWells', {
     type: 'geojson',
     data: orphanedWellsURL
@@ -54,11 +62,22 @@ const drawWells = (map: maplibre.Map, wells: any) => {
     },
     paint: {
       'circle-radius': 5,
-      'circle-color': 'red'
+      'circle-color': [
+        'case',
+        assessedStyle,
+        'salmon',
+        inactiveStyle,
+        'gray',
+        decommissionedStyle,
+        'blue',
+        reclaimedStyle,
+        'green',
+        'black'
+      ]
     }
   });
 
-  // Orphaned activities
+  // Orphaned activities - These are called "Activities" on the BCER site
   map.addSource('orphanedActivities', {
     type: 'geojson',
     data: orphanedActivitiesURL
@@ -68,15 +87,16 @@ const drawWells = (map: maplibre.Map, wells: any) => {
     type: 'circle',
     source: 'orphanedActivities',
     layout: {
-      visibility: wells[0] ? 'visible' : 'none'
+      visibility: 'none'
+      // visibility: wells[0] ? 'visible' : 'none'
     },
     paint: {
       'circle-radius': 5,
-      'circle-color': 'blue'
+      'circle-color': 'black'
     }
   });
 
-  // Surface state
+  // Surface state - May not need these
   map.addSource('surfaceState', {
     type: 'geojson',
     data: surfaceStateURL
@@ -86,7 +106,8 @@ const drawWells = (map: maplibre.Map, wells: any) => {
     type: 'circle',
     source: 'surfaceState',
     layout: {
-      visibility: wells[0] ? 'visible' : 'none'
+      // visibility: wells[0] ? 'visible' : 'none'
+      visibility: 'none'
     },
     paint: {
       'circle-radius': 5,

--- a/app/src/components/map/MapContainer2.tsx
+++ b/app/src/components/map/MapContainer2.tsx
@@ -37,8 +37,6 @@ const drawWells = (map: maplibre.Map, wells: any) => {
     'https://geoweb-ags.bc-er.ca/arcgis/rest/services/OPERATIONAL/ORPHAN_SITE_PT/MapServer/0/query?outFields=*&where=1%3D1&f=geojson';
   const orphanedActivitiesURL =
     'https://geoweb-ags.bc-er.ca/arcgis/rest/services/OPERATIONAL/ORPHAN_ACTIVITY_PT/FeatureServer/0/query?outFields=*&where=1%3D1&f=geojson';
-  const surfaceStateURL =
-    'https://geoweb-ags.bc-er.ca/arcgis/rest/services/PASR/PASR_WELL_SURFACE_STATE_PT/MapServer/0/query?outFields=*&where=1%3D1&f=geojson';
 
   map.addSource('orphanedWells', {
     type: 'geojson',
@@ -82,31 +80,45 @@ const drawWells = (map: maplibre.Map, wells: any) => {
     type: 'circle',
     source: 'orphanedActivities',
     layout: {
-      visibility: 'none'
-      // visibility: wells[0] ? 'visible' : 'none'
+      visibility: wells[0] ? 'visible' : 'none'
     },
     paint: {
-      'circle-radius': 5,
-      'circle-color': 'black'
-    }
-  });
-
-  // Surface state - May not need these
-  map.addSource('surfaceState', {
-    type: 'geojson',
-    data: surfaceStateURL
-  });
-  map.addLayer({
-    id: 'surfaceStateLayer',
-    type: 'circle',
-    source: 'surfaceState',
-    layout: {
-      // visibility: wells[0] ? 'visible' : 'none'
-      visibility: 'none'
-    },
-    paint: {
-      'circle-radius': 5,
-      'circle-color': 'green'
+      'circle-radius': [
+        'match',
+        ['get', 'WORKSTREAM_SHORT'],
+        'Deactivation',
+        8,
+        'Abandonment',
+        10,
+        'Decommissioning',
+        12,
+        'Investigation',
+        14,
+        'Remediation',
+        16,
+        'Reclamation',
+        18,
+        0
+      ],
+      'circle-color': 'rgba(0, 0, 0, 0)',
+      'circle-stroke-width': 3,
+      'circle-stroke-color': [
+        'match',
+        ['get', 'WORKSTREAM_SHORT'],
+        'Deactivation',
+        '#fffe7d',
+        'Abandonment',
+        '#ee212f',
+        'Decommissioning',
+        '#4a72b5',
+        'Investigation',
+        '#f6b858',
+        'Remediation',
+        '#a92fe2',
+        'Reclamation',
+        '#709958',
+        'black'
+      ]
     }
   });
 };
@@ -509,8 +521,7 @@ const checkLayerVisibility = (layers: any, features: any) => {
     if (
       layer === 'wells' &&
       map.getLayer('orphanedWellsLayer') &&
-      map.getLayer('orphanedActivitiesLayer') &&
-      map.getLayer('surfaceStateLayer')
+      map.getLayer('orphanedActivitiesLayer')
     ) {
       map.setLayoutProperty(
         'orphanedWellsLayer',
@@ -519,11 +530,6 @@ const checkLayerVisibility = (layers: any, features: any) => {
       );
       map.setLayoutProperty(
         'orphanedActivitiesLayer',
-        'visibility',
-        layers[layer][0] ? 'visible' : 'none'
-      );
-      map.setLayoutProperty(
-        'surfaceStateLayer',
         'visibility',
         layers[layer][0] ? 'visible' : 'none'
       );


### PR DESCRIPTION
Styled the layer to match the symbology chosen by the data [vendor](https://data-bc-er.opendata.arcgis.com/).

Orphaned Sites
![Screenshot from 2024-04-24 10-04-49](https://github.com/bcgov/nert-restoration-tracker/assets/479074/3fbc20a1-49c2-4bbb-9d7d-c8b9519c38fb)

Orphaned Activities
![Screenshot from 2024-04-24 10-53-29](https://github.com/bcgov/nert-restoration-tracker/assets/479074/35342871-e22a-48b2-8768-8567596efa85)

... and together
![Screenshot from 2024-04-24 10-53-47](https://github.com/bcgov/nert-restoration-tracker/assets/479074/543a7335-907a-4744-814f-b0d3685269da)
