### PR TITLE
Geojson upload feature

### DIFF
--- a/app/src/components/attachments/DropZone.tsx
+++ b/app/src/components/attachments/DropZone.tsx
@@ -76,12 +76,6 @@ export const DropZone: React.FC<IDropZoneProps & IDropZoneConfigProps> = (props)
   const maxNumFiles = props.maxNumFiles || config?.MAX_UPLOAD_NUM_FILES;
   const maxFileSize = props.maxFileSize || config?.MAX_UPLOAD_FILE_SIZE;
   const multiple = props.multiple ?? true;
-  // const acceptedFileExtensions = props.acceptedFileExtensions;
-  const acceptedFileExtensions = {
-    'application/vnd.google-earth.kml+xml': ['.kml'],
-    'application/octet-stream': ['.gpx'],
-    'application/zip': ['.zip']
-  };
 
   return (
     <Box className="dropZoneContainer">
@@ -101,13 +95,11 @@ export const DropZone: React.FC<IDropZoneProps & IDropZoneConfigProps> = (props)
                 <Link underline="always">Browse Files</Link>
               </Box>
               <Box textAlign="center">
-                {acceptedFileExtensions && (
-                  <Box>
-                    <Typography component="span" variant="subtitle2" color="textSecondary">
-                      {`Accepted files: ${acceptedFileExtensions}`}
-                    </Typography>
-                  </Box>
-                )}
+                <Box>
+                  <Typography component="span" variant="subtitle2" color="textSecondary">
+                    {`Accepted files: GeoJSON`}
+                  </Typography>
+                </Box>
                 {!!maxFileSize && maxFileSize !== Infinity && (
                   <Box>
                     <Typography component="span" variant="subtitle2" color="textSecondary">

--- a/app/src/features/projects/components/ProjectLocationForm.tsx
+++ b/app/src/features/projects/components/ProjectLocationForm.tsx
@@ -21,11 +21,7 @@ import MapContainer from 'components/map/MapContainer';
 import { useFormikContext } from 'formik';
 import { Feature } from 'geojson';
 import React, { useState } from 'react';
-import {
-  handleGPXUpload,
-  handleKMLUpload,
-  handleShapefileUpload
-} from 'utils/mapBoundaryUploadHelpers';
+import { handleGeoJSONUpload } from 'utils/mapBoundaryUploadHelpers';
 import yup from 'utils/YupSchema';
 
 export interface IProjectLocationForm {
@@ -77,12 +73,8 @@ const ProjectLocationForm: React.FC<IProjectLocationFormProps> = (props) => {
 
   const getUploadHandler = (): IUploadHandler => {
     return async (file) => {
-      if (file?.type.includes('zip') || file?.name.includes('.zip')) {
-        handleShapefileUpload(file, 'location.geometry', formikProps);
-      } else if (file?.type.includes('gpx') || file?.name.includes('.gpx')) {
-        handleGPXUpload(file, 'location.geometry', formikProps);
-      } else if (file?.type.includes('kml') || file?.name.includes('.kml')) {
-        handleKMLUpload(file, 'location.geometry', formikProps);
+      if (file?.type.includes('json') || file?.name.includes('.json')) {
+        handleGeoJSONUpload(file, 'location.geometry', formikProps);
       }
 
       return Promise.resolve();
@@ -188,8 +180,8 @@ const ProjectLocationForm: React.FC<IProjectLocationFormProps> = (props) => {
         <Typography component="legend">Project Boundary *</Typography>
         <Box mb={3} maxWidth={'72ch'}>
           <Typography variant="body1" color="textSecondary">
-            Upload a shapefile or use the drawing tools on the map to define your project boundary
-            (KML or shapefiles accepted).
+            Upload a GeoJSON file or use the drawing tools on the map to define your project
+            boundary.
           </Typography>
         </Box>
 
@@ -233,9 +225,7 @@ const ProjectLocationForm: React.FC<IProjectLocationFormProps> = (props) => {
           uploadHandler={getUploadHandler()}
           dropZoneProps={{
             acceptedFileExtensions: {
-              'application/vnd.google-earth.kml+xml': ['.kml'],
-              'application/octet-stream': ['.gpx'],
-              'application/zip': ['.zip']
+              'application/json': ['.json', '.geojson']
             }
           }}
         />

--- a/app/src/utils/mapBoundaryUploadHelpers.ts
+++ b/app/src/utils/mapBoundaryUploadHelpers.ts
@@ -140,6 +140,45 @@ export const handleKMLUpload = async <T>(
 };
 
 /**
+ *
+ * @param file File object to upload
+ * @param name Name of the formik field that the parsed geometry will be saved to
+ * @param formikProps The formik props
+ * @returns
+ */
+export const handleGeoJSONUpload = async <T>(
+  file: File,
+  name: string,
+  formikProps: FormikContextType<T>
+) => {
+  const { values, setFieldValue, setFieldError } = formikProps;
+
+  const fileAsString = await file?.text().then((jsonString: string) => {
+    return jsonString;
+  });
+
+  if (!file?.type.includes('json') && !fileAsString?.includes('FeatureCollection')) {
+    setFieldError(name, 'You must upload a GeoJSON file, please try again.');
+    return;
+  }
+
+  try {
+    const geojson = JSON.parse(fileAsString);
+
+    if (geojson?.features) {
+      setFieldValue(name, [...geojson.features, ...get(values, name)]);
+    } else {
+      setFieldError(
+        name,
+        'Error uploading your GeoJSON file, please check the file and try again.'
+      );
+    }
+  } catch (error) {
+    setFieldError(name, 'Error uploading your GeoJSON file, please check the file and try again.');
+  }
+};
+
+/**
  * Calculates the bounding box that encompasses all of the given features
  *
  * @param features The features used to calculate the bounding box


### PR DESCRIPTION
- Upload interface now communicates only GeoJSON files can be uploaded
- Removed kml, gpx & shp/zip upload features
- GeoJSON is added to the map through drag/drop and the native file browser

![Screenshot from 2024-04-29 10-31-45](https://github.com/bcgov/nert-restoration-tracker/assets/479074/80365db0-7784-41da-8bb0-fd29e9865c88)

![Screenshot from 2024-04-29 10-31-52](https://github.com/bcgov/nert-restoration-tracker/assets/479074/10034115-1533-412a-88ff-df15d20d7fee)
