### PR TITLE
NERT-530 conservation areas disabling add button other fixes

### DIFF
--- a/app/src/features/projects/components/ProjectLocationConservationAreasForm.tsx
+++ b/app/src/features/projects/components/ProjectLocationConservationAreasForm.tsx
@@ -11,7 +11,7 @@ import Typography from '@mui/material/Typography';
 import CustomTextField from 'components/fields/CustomTextField';
 import { FieldArray, useFormikContext } from 'formik';
 import React from 'react';
-import { IProjectLocationForm } from './ProjectLocationForm';
+import { IProjectLocationForm } from 'features/projects/components/ProjectLocationForm';
 
 const pageStyles = {
   customListItem: {
@@ -65,8 +65,7 @@ const ProjectLocationConservationAreas: React.FC = () => {
                                 maxLength={100}
                                 other={{
                                   disabled: values.location.is_within_overlapping !== 'true',
-                                  required:
-                                    values.location.is_within_overlapping === 'true' ? true : false,
+                                  required: !index ? true : false,
                                   value: conservationArea.conservationArea,
                                   error:
                                     conservationAreaMeta.touched &&
@@ -100,8 +99,12 @@ const ProjectLocationConservationAreas: React.FC = () => {
               <Box pt={0.5}>
                 <Button
                   disabled={
-                    values.location.conservationAreas.length >= 5 ||
-                    values.location.is_within_overlapping !== 'true'
+                    !!values.location.conservationAreas.length &&
+                    (!values.location.conservationAreas[
+                      values.location.conservationAreas.length - 1
+                    ].conservationArea.trim() ||
+                      values.location.conservationAreas.length >= 5 ||
+                      values.location.is_within_overlapping !== 'true')
                   }
                   type="button"
                   variant="outlined"

--- a/app/src/features/projects/components/ProjectLocationForm.tsx
+++ b/app/src/features/projects/components/ProjectLocationForm.tsx
@@ -27,7 +27,7 @@ import MapContainer from 'components/map/MapContainer';
 import MapFeatureList from 'components/map/components/MapFeatureList';
 import { useFormikContext } from 'formik';
 import { Feature } from 'geojson';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { handleGeoJSONUpload } from 'utils/mapBoundaryUploadHelpers';
 import yup from 'utils/YupSchema';
 import './styles/projectLocation.css';
@@ -72,13 +72,13 @@ export const ProjectLocationFormYupSchema = yup.object().shape({
       .array()
       .of(
         yup.object().shape({
-          conservationArea: yup.string().max(100, 'Cannot exceed 100 characters').nullable()
+          conservationArea: yup.string().max(100, 'Cannot exceed 100 characters.').nullable()
         })
       )
-      .isUniqueConservationArea('Conservation area entries must be unique')
+      .isUniqueConservationArea('Conservation area entries must be unique.')
       .isConservationAreasRequired(
         'is_within_overlapping',
-        'Conservation areas are required when project is within or overlapping a known area of cultural or conservation'
+        'At least one conservation areas is required when project is within or overlapping a known area of cultural or conservation.'
       )
   })
 });

--- a/app/src/features/projects/components/ProjectObjectivesForm.tsx
+++ b/app/src/features/projects/components/ProjectObjectivesForm.tsx
@@ -50,12 +50,14 @@ export const ProjectObjectiveFormYupSchema = yup.object().shape({
         yup.object().shape({
           objective: yup
             .string()
-            .max(300, 'Cannot exceed 500 characters')
             .trim()
-            .required('Please enter an objective')
+            .nullable()
+            .transform((value, orig) => (orig.trim() === '' ? null : value))
+            .max(300, 'Objective cannot exceed 500 characters.')
+            .required('Project objective is required.')
         })
       )
-      .isUniqueObjective('Objective entries must be unique')
+      .isUniqueObjective('Objective entries must be unique.')
   })
 });
 
@@ -89,7 +91,7 @@ const ProjectObjectivesForm: React.FC = () => {
                               label="Objective"
                               maxLength={200}
                               other={{
-                                required: !index ? true : false,
+                                required: true,
                                 value: objective.objective,
                                 error: objectiveMeta.touched && Boolean(objectiveMeta.error),
                                 helperText: objectiveMeta.touched && objectiveMeta.error

--- a/app/src/features/projects/components/ProjectPartnershipsForm.tsx
+++ b/app/src/features/projects/components/ProjectPartnershipsForm.tsx
@@ -50,11 +50,12 @@ export const ProjectPartnershipFormYupSchema = yup.object().shape({
         yup.object().shape({
           partnership: yup
             .string()
+            .nullable()
             .transform((value, orig) => (orig.trim() === '' ? null : value))
-            .max(300, 'Cannot exceed 300 characters')
+            .max(300, 'Cannot exceed 300 characters.')
         })
       )
-      .isUniquePartnership('Parnership entries must be unique')
+      .isUniquePartnership('Partnership entries must be unique.')
   })
 });
 

--- a/app/src/features/projects/edit/EditProjectPage.tsx
+++ b/app/src/features/projects/edit/EditProjectPage.tsx
@@ -3,7 +3,6 @@ import Box from '@mui/material/Box';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
-import Container from '@mui/material/Container';
 import Card from '@mui/material/Card';
 import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
@@ -139,6 +138,11 @@ const EditProjectPage: React.FC = () => {
     // Remove empty Authorizations
     values.authorization.authorizations = values.authorization.authorizations.filter(
       (authorization) => authorization.authorization_type.trim()
+    );
+
+    // Remove empty Conservation Areas
+    values.location.conservationAreas = values.location.conservationAreas.filter((area) =>
+      area.conservationArea.trim()
     );
 
     // Set size_ha to 0 if it is not set


### PR DESCRIPTION
## Links to Jira Tickets

- NERT-530

## Description of Changes

- Add new conservation area button disabled when required
- When adding a new project objective is now required 
- validation improvements