### PR TITLE
NERT-578 Organization column show with chips plan and project list view

### DIFF
--- a/api/src/paths/public/plans.ts
+++ b/api/src/paths/public/plans.ts
@@ -247,7 +247,7 @@ export function getPublicPlansList(): RequestHandler {
       const planService = new PlanService(connection);
 
       // Get all projects data for the projectIds
-      const projects = await planService.getPlansByIds(projectIds);
+      const projects = await planService.getPlansByIds(projectIds, true);
 
       await connection.commit();
 

--- a/api/src/paths/public/projects.ts
+++ b/api/src/paths/public/projects.ts
@@ -430,7 +430,7 @@ export function getPublicProjectsPlansList(): RequestHandler {
       const projectService = new ProjectService(connection);
 
       // Get all projects data for the projectIds
-      const projects = await projectService.getProjectsByIds(projectIds);
+      const projects = await projectService.getProjectsByIds(projectIds, true);
 
       await connection.commit();
 

--- a/app/src/features/plans/PlanListPage.tsx
+++ b/app/src/features/plans/PlanListPage.tsx
@@ -36,7 +36,7 @@ import {
 import { DATE_FORMAT } from 'constants/dateTimeFormats';
 import { PlanTableI18N, TableI18N } from 'constants/i18n';
 import { SYSTEM_ROLE } from 'constants/roles';
-import React, { useContext, useState } from 'react';
+import React, { Fragment, useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as utils from 'utils/pagedProjectPlanTableUtils';
 import { getDateDiffInMonths, getFormattedDate } from 'utils/Utils';
@@ -73,7 +73,7 @@ const PlanListPage: React.FC<IPlansListProps> = (props) => {
           getDateDiffInMonths(row.project.start_date, row.project.end_date) > 12
             ? PlanTableI18N.multiYear
             : PlanTableI18N.annual,
-        org: row.contact.contacts.map((item) => item.organization).join(', '),
+        org: row.contact.contacts.map((item) => item.organization).join('\r'),
         startDate: row.project.start_date,
         endDate: row.project.end_date,
         statusCode: row.project.state_code,
@@ -309,6 +309,16 @@ const PlanListPage: React.FC<IPlansListProps> = (props) => {
       [order, orderBy, page, rowsPerPage]
     );
 
+    const orgTooltip = (org: string) => {
+      return (
+        <Tooltip title={org} disableHoverListener={org.length < 35}>
+          <Typography sx={utils.orgStyles.orgLabel} aria-label={`${org}`}>
+            {org}
+          </Typography>
+        </Tooltip>
+      );
+    };
+
     return (
       <Box sx={{ width: '100%' }}>
         <PlansTableToolbar numSelected={selected.length} />
@@ -355,7 +365,29 @@ const PlanListPage: React.FC<IPlansListProps> = (props) => {
                       </Link>
                     </TableCell>
                     <TableCell align="left">{row.term}</TableCell>
-                    <TableCell align="left">{row.org}</TableCell>
+                    <TableCell align="left">
+                      {row.org &&
+                        row.org.split('\r').map((organization: string, key) => (
+                          <Fragment key={key}>
+                            <Box>
+                              <Chip
+                                data-testid="organization_item"
+                                size="small"
+                                sx={utils.orgStyles.orgPlanChip}
+                                label={orgTooltip(organization)}
+                              />
+                            </Box>
+                          </Fragment>
+                        ))}
+
+                      {!row.org && (
+                        <Chip
+                          label="No Organizations"
+                          sx={utils.orgStyles.noOrgChip}
+                          data-testid="no_organizations_loaded"
+                        />
+                      )}
+                    </TableCell>
                     <TableCell align="left">
                       {getFormattedDate(DATE_FORMAT.ShortMediumDateFormat, row.startDate)}
                     </TableCell>

--- a/app/src/features/plans/components/PlanContactItemForm.tsx
+++ b/app/src/features/plans/components/PlanContactItemForm.tsx
@@ -40,12 +40,12 @@ export const PlanContactItemYupSchema = yup.object().shape({
   last_name: yup.string().max(50, 'Cannot exceed 50 characters').required('Required'),
   email_address: yup
     .string()
-    .max(500, 'Cannot exceed 500 characters')
+    .max(300, 'Cannot exceed 300 characters')
     .email('Must be a valid email address')
     .required('Required'),
   organization: yup
     .string()
-    .max(300, 'Cannot exceed 300 characters')
+    .max(100, 'Cannot exceed 100 characters')
     .required('Required')
     .nullable(),
   is_public: yup.string().required('Required'),

--- a/app/src/features/projects/components/ProjectAuthorizationForm.tsx
+++ b/app/src/features/projects/components/ProjectAuthorizationForm.tsx
@@ -73,7 +73,7 @@ export const ProjectAuthorizationFormYupSchema = yup.object().shape({
             .transform((value, orig) => (orig.trim() === '' ? null : value))
             .max(200, 'Cannot exceed 200 characters')
             .isAuthDescriptionRequired(
-              'Other',
+              'Other - please specify',
               'Authorization Description is required when Authorization Type is "Other"'
             )
         })
@@ -182,7 +182,9 @@ const ProjectAuthorizationForm: React.FC = () => {
                                 label="Authorization Description"
                                 other={{
                                   disabled: !authorization.authorization_type,
-                                  required: !(authorization.authorization_type != 'Other'),
+                                  required: !(
+                                    authorization.authorization_type != 'Other - please specify'
+                                  ),
                                   value: authorization.authorization_desc,
                                   error:
                                     authorizationDescMeta.touched &&

--- a/app/src/features/projects/components/ProjectContactItemForm.tsx
+++ b/app/src/features/projects/components/ProjectContactItemForm.tsx
@@ -36,12 +36,12 @@ export const ProjectContactItemYupSchema = yup.object().shape({
   last_name: yup.string().max(50, 'Cannot exceed 50 characters').required('Required'),
   email_address: yup
     .string()
-    .max(500, 'Cannot exceed 500 characters')
+    .max(300, 'Cannot exceed 300 characters')
     .email('Must be a valid email address')
     .required('Required'),
   organization: yup
     .string()
-    .max(300, 'Cannot exceed 300 characters')
+    .max(100, 'Cannot exceed 100 characters')
     .required('Required')
     .nullable(),
   is_public: yup.string().required('Required'),

--- a/app/src/features/projects/list/ProjectsListPage.tsx
+++ b/app/src/features/projects/list/ProjectsListPage.tsx
@@ -78,7 +78,7 @@ const ProjectsListPage: React.FC<IProjectsListProps> = (props) => {
               item.authorization_type + '\n' + item.authorization_ref
           )
           .join('\r'),
-        org: row.contact.contacts.map((item) => item.organization).join(', '),
+        org: row.contact.contacts.map((item) => item.organization).join('\r'),
         plannedStartDate: row.project.start_date,
         plannedEndDate: row.project.end_date,
         actualStartDate: row.project.actual_start_date,
@@ -314,6 +314,16 @@ const ProjectsListPage: React.FC<IProjectsListProps> = (props) => {
       );
     };
 
+    const orgTooltip = (org: string) => {
+      return (
+        <Tooltip title={org} disableHoverListener={org.length < 35}>
+          <Typography sx={utils.orgStyles.orgLabel} aria-label={`${org}`}>
+            {org}
+          </Typography>
+        </Tooltip>
+      );
+    };
+
     return (
       <Box sx={{ width: '100%' }}>
         <ProjectsTableToolbar numSelected={selected.length} />
@@ -395,7 +405,29 @@ const ProjectsListPage: React.FC<IProjectsListProps> = (props) => {
                           </Fragment>
                         ))}
                     </TableCell>
-                    <TableCell align="left">{row.org}</TableCell>
+                    <TableCell align="left">
+                      {row.org &&
+                        row.org.split('\r').map((organization: string, key) => (
+                          <Fragment key={key}>
+                            <Box>
+                              <Chip
+                                data-testid="organization_item"
+                                size="small"
+                                sx={utils.orgStyles.orgProjectChip}
+                                label={orgTooltip(organization)}
+                              />
+                            </Box>
+                          </Fragment>
+                        ))}
+
+                      {!row.org && (
+                        <Chip
+                          label="No Organizations"
+                          sx={utils.orgStyles.noOrgChip}
+                          data-testid="no_organizations_loaded"
+                        />
+                      )}
+                    </TableCell>
                     <TableCell align="left">
                       {getFormattedDate(DATE_FORMAT.ShortMediumDateFormat, row.plannedStartDate)}
                     </TableCell>

--- a/app/src/pages/public/list/PublicPlansListPage.tsx
+++ b/app/src/pages/public/list/PublicPlansListPage.tsx
@@ -31,7 +31,7 @@ import {
 import { DATE_FORMAT } from 'constants/dateTimeFormats';
 import { PlanTableI18N, TableI18N } from 'constants/i18n';
 import { IPlansListProps } from 'features/user/MyPlans';
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as utils from 'utils/pagedProjectPlanTableUtils';
 import { getDateDiffInMonths, getFormattedDate } from 'utils/Utils';
@@ -55,7 +55,7 @@ const PublicPlanListPage: React.FC<IPlansListProps> = (props) => {
           getDateDiffInMonths(row.project.start_date, row.project.end_date) > 12
             ? PlanTableI18N.multiYear
             : PlanTableI18N.annual,
-        org: row.contact.contacts.map((item) => item.organization).join(', '),
+        org: row.contact.contacts.map((item) => item.organization).join('\r'),
         startDate: row.project.start_date,
         endDate: row.project.end_date,
         statusCode: row.project.state_code,
@@ -246,6 +246,16 @@ const PublicPlanListPage: React.FC<IPlansListProps> = (props) => {
       [order, orderBy, page, rowsPerPage]
     );
 
+    const orgTooltip = (org: string) => {
+      return (
+        <Tooltip title={org} disableHoverListener={org.length < 35}>
+          <Typography sx={utils.orgStyles.orgLabel} aria-label={`${org}`}>
+            {org}
+          </Typography>
+        </Tooltip>
+      );
+    };
+
     return (
       <Box sx={{ width: '100%' }}>
         <PlansTableToolbar numSelected={selected.length} />
@@ -288,7 +298,29 @@ const PublicPlanListPage: React.FC<IPlansListProps> = (props) => {
                       </Link>
                     </TableCell>
                     <TableCell align="left">{row.term}</TableCell>
-                    <TableCell align="left">{row.org}</TableCell>
+                    <TableCell align="left">
+                      {row.org &&
+                        row.org.split('\r').map((organization: string, key) => (
+                          <Fragment key={key}>
+                            <Box>
+                              <Chip
+                                data-testid="organization_item"
+                                size="small"
+                                sx={utils.orgStyles.orgPlanChip}
+                                label={orgTooltip(organization)}
+                              />
+                            </Box>
+                          </Fragment>
+                        ))}
+
+                      {!row.org && (
+                        <Chip
+                          label="No Organizations"
+                          sx={utils.orgStyles.noOrgChip}
+                          data-testid="no_organizations_loaded"
+                        />
+                      )}
+                    </TableCell>
                     <TableCell align="left">
                       {getFormattedDate(DATE_FORMAT.ShortMediumDateFormat, row.startDate)}
                     </TableCell>

--- a/app/src/pages/public/list/PublicProjectsListPage.tsx
+++ b/app/src/pages/public/list/PublicProjectsListPage.tsx
@@ -57,7 +57,7 @@ const PublicProjectsListPage: React.FC<IProjectsListProps> = (props) => {
               item.authorization_type + '\n' + item.authorization_ref
           )
           .join('\r'),
-        org: row.contact.contacts.map((item) => item.organization).join(', '),
+        org: row.contact.contacts.map((item) => item.organization).join('\r'),
         plannedStartDate: row.project.start_date,
         plannedEndDate: row.project.end_date,
         actualStartDate: row.project.actual_start_date,
@@ -249,6 +249,16 @@ const PublicProjectsListPage: React.FC<IProjectsListProps> = (props) => {
       );
     };
 
+    const orgTooltip = (org: string) => {
+      return (
+        <Tooltip title={org} disableHoverListener={org.length < 35}>
+          <Typography sx={utils.orgStyles.orgLabel} aria-label={`${org}`}>
+            {org}
+          </Typography>
+        </Tooltip>
+      );
+    };
+
     return (
       <Box sx={{ width: '100%' }}>
         <ProjectsTableToolbar numSelected={selected.length} />
@@ -329,7 +339,29 @@ const PublicProjectsListPage: React.FC<IProjectsListProps> = (props) => {
                         />
                       )}
                     </TableCell>
-                    <TableCell align="left">{row.org}</TableCell>
+                    <TableCell align="left">
+                      {row.org &&
+                        row.org.split('\r').map((organization: string, key) => (
+                          <Fragment key={key}>
+                            <Box>
+                              <Chip
+                                data-testid="organization_item"
+                                size="small"
+                                sx={utils.orgStyles.orgProjectChip}
+                                label={orgTooltip(organization)}
+                              />
+                            </Box>
+                          </Fragment>
+                        ))}
+
+                      {!row.org && (
+                        <Chip
+                          label="No Organizations"
+                          sx={utils.orgStyles.noOrgChip}
+                          data-testid="no_organizations_loaded"
+                        />
+                      )}
+                    </TableCell>
                     <TableCell align="left">
                       {getFormattedDate(DATE_FORMAT.ShortMediumDateFormat, row.plannedStartDate)}
                     </TableCell>

--- a/app/src/utils/pagedProjectPlanTableUtils.ts
+++ b/app/src/utils/pagedProjectPlanTableUtils.ts
@@ -247,3 +247,34 @@ export const authStyles = {
     textOverflow: 'ellipsis'
   }
 };
+
+export const orgStyles = {
+  orgProjectChip: {
+    backgroundColor: '#E9FBFF',
+    marginBottom: '1px',
+    justifyContent: 'left',
+    maxWidth: '230px',
+    width: '100%'
+  },
+  orgPlanChip: {
+    backgroundColor: '#FFF4EB',
+    marginBottom: '1px',
+    justifyContent: 'left',
+    maxWidth: '230px',
+    width: '100%'
+  },
+  noOrgChip: {
+    justifyContent: 'left',
+    fontSize: '0.78rem',
+    fontWeight: 500,
+    height: '1.5rem'
+  },
+  orgLabel: {
+    color: '#545454',
+    fontSize: '0.78rem',
+    fontWeight: 500,
+    textTransform: 'none',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis'
+  }
+};


### PR DESCRIPTION
## Links to Jira Tickets

- NERT-578

## Description of Changes

- Non Auth view now properly uses the public API to get the projects/plans organization contacts
- Auth project and plan list view shows organizations with chip component
- fixed contacts max characters validation to match the db table defined sizes

