### PR TITLE
NERT-663 Removed logic that disables plan checkboxes

### DIFF
--- a/app/src/features/plans/PlanListPage.tsx
+++ b/app/src/features/plans/PlanListPage.tsx
@@ -102,14 +102,7 @@ const PlanListPage: React.FC<IPlansListProps> = (props) => {
           statusCode: row.project.state_code,
           statusLabel: getStateLabelFromCode(row.project.state_code),
           statusStyle: getStatusStyle(row.project.state_code),
-          archive: row.project.state_code !== archCode ? TableI18N.archive : TableI18N.unarchive,
-          export:
-            row.project.is_healing_people &&
-            !row.project.is_healing_land &&
-            !row.project.is_cultural_initiative &&
-            !row.project.is_land_initiative
-              ? ''
-              : 'Yes'
+          archive: row.project.state_code !== archCode ? TableI18N.archive : TableI18N.unarchive
         } as utils.PlanData;
       });
 
@@ -129,8 +122,7 @@ const PlanListPage: React.FC<IPlansListProps> = (props) => {
               statusCode: draftCode,
               statusLabel: states.DRAFT,
               statusStyle: draftStatusStyle,
-              archive: '',
-              export: ''
+              archive: ''
             } as utils.PlanData;
           })
       : [];
@@ -169,7 +161,7 @@ const PlanListPage: React.FC<IPlansListProps> = (props) => {
 
     const handleSelectAllClick = (event: React.ChangeEvent<HTMLInputElement>) => {
       if (event.target.checked) {
-        const newSelected = rows.filter((item) => item.export).map((n) => n.id);
+        const newSelected = rows.map((n) => n.id);
         setSelected(newSelected);
         return;
       }
@@ -559,36 +551,20 @@ const PlanListPage: React.FC<IPlansListProps> = (props) => {
                     </TableCell>
                     {!myPlan ? (
                       <TableCell padding="checkbox">
-                        {row.export ? (
-                          <Tooltip
-                            title={
-                              isItemSelected
-                                ? TableI18N.exportSelected
-                                : TableI18N.exportNotSelected
-                            }
-                            placement="right">
-                            <Checkbox
-                              color="primary"
-                              checked={isItemSelected}
-                              inputProps={{
-                                'aria-labelledby': labelId
-                              }}
-                              onClick={(event) => handleClick(event, row.id)}
-                            />
-                          </Tooltip>
-                        ) : (
-                          <Tooltip title={TableI18N.noDataToExport} placement="right">
-                            <span>
-                              <Checkbox
-                                disabled={true}
-                                color="primary"
-                                inputProps={{
-                                  'aria-labelledby': labelId
-                                }}
-                              />
-                            </span>
-                          </Tooltip>
-                        )}
+                        <Tooltip
+                          title={
+                            isItemSelected ? TableI18N.exportSelected : TableI18N.exportNotSelected
+                          }
+                          placement="right">
+                          <Checkbox
+                            color="primary"
+                            checked={isItemSelected}
+                            inputProps={{
+                              'aria-labelledby': labelId
+                            }}
+                            onClick={(event) => handleClick(event, row.id)}
+                          />
+                        </Tooltip>
                       </TableCell>
                     ) : (
                       <></>

--- a/app/src/features/search/SearchPage.tsx
+++ b/app/src/features/search/SearchPage.tsx
@@ -65,7 +65,7 @@ const SearchPage: React.FC = () => {
           .geometryCollection[0];
 
         // Filter out archived projects/plans
-        if ( archCode != result.state_code) {
+        if (archCode != result.state_code) {
           clusteredPointGeometries.push({
             position: centroid(feature as any).geometry.coordinates as LatLngTuple,
             feature: result

--- a/app/src/features/search/SearchPage.tsx
+++ b/app/src/features/search/SearchPage.tsx
@@ -13,6 +13,7 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { generateValidGeometryCollection } from 'utils/mapBoundaryUploadHelpers';
 import ArrowBack from '@mui/icons-material/ArrowBack';
 import LayersIcon from '@mui/icons-material/Layers';
+import { getStateCodeFromLabel, states } from 'components/workflow/StateMachine';
 
 /**
  * Page to search for and display a list of records spatially.
@@ -45,6 +46,7 @@ const SearchPage: React.FC = () => {
     },
     [dialogContext]
   );
+  const archCode = getStateCodeFromLabel(states.ARCHIVED);
   const getSearchResults = useCallback(async () => {
     try {
       const response = authStateContext.nertUserWrapper.hasOneOrMoreProjectRoles
@@ -62,10 +64,13 @@ const SearchPage: React.FC = () => {
         const feature = generateValidGeometryCollection(result.geometry, result.id)
           .geometryCollection[0];
 
-        clusteredPointGeometries.push({
-          position: centroid(feature as any).geometry.coordinates as LatLngTuple,
-          feature: result
-        });
+        // Filter out archived projects/plans
+        if ( archCode != result.state_code) {
+          clusteredPointGeometries.push({
+            position: centroid(feature as any).geometry.coordinates as LatLngTuple,
+            feature: result
+          });
+        }
       });
 
       setPerformSearch(false);

--- a/app/src/hooks/api/usePlanApi.ts
+++ b/app/src/hooks/api/usePlanApi.ts
@@ -45,18 +45,6 @@ const usePlanApi = (axios: AxiosInstance) => {
   };
 
   /**
-   * Delete Plan based on Plan ID
-   *
-   * @param {number} planId
-   * @returns {*} {Promise<boolean>}
-   */
-  const deletePlan = async (planId: number): Promise<boolean> => {
-    const { data } = await axios.delete(`/api/plan/${planId}/delete`);
-
-    return data;
-  };
-
-  /**
    * Get plans list (potentially based on filter criteria).
    *
    * @param {IPlansAdvancedFilterRequest} filterFieldData
@@ -226,7 +214,6 @@ const usePlanApi = (axios: AxiosInstance) => {
     getPlanById,
     getPlanByIdForUpdate,
     updatePlan,
-    deletePlan,
     getUserPlansList,
     uploadPlanAttachments,
     deletePlanThumbnail,

--- a/app/src/pages/public/list/PublicPlansListPage.tsx
+++ b/app/src/pages/public/list/PublicPlansListPage.tsx
@@ -75,14 +75,7 @@ const PublicPlanListPage: React.FC<IPlansListProps> = (props) => {
         statusCode: row.project.state_code,
         statusLabel: getStateLabelFromCode(row.project.state_code),
         statusStyle: getStatusStyle(row.project.state_code),
-        archive: '',
-        export:
-          row.project.is_healing_people &&
-          !row.project.is_healing_land &&
-          !row.project.is_cultural_initiative &&
-          !row.project.is_land_initiative
-            ? ''
-            : 'Yes'
+        archive: ''
       } as utils.PlanData;
     });
 
@@ -119,7 +112,7 @@ const PublicPlanListPage: React.FC<IPlansListProps> = (props) => {
         <TableHead>
           <TableRow>
             {utils.planHeadCells.map((headCell) => {
-              if ('archive' !== headCell.id && 'export' !== headCell.id)
+              if ('archive' !== headCell.id)
                 return (
                   <TableCell
                     key={headCell.id}
@@ -236,7 +229,7 @@ const PublicPlanListPage: React.FC<IPlansListProps> = (props) => {
 
     const handleSelectAllClick = (event: React.ChangeEvent<HTMLInputElement>) => {
       if (event.target.checked) {
-        const newSelected = rows.filter((item) => item.export).map((n) => n.id);
+        const newSelected = rows.map((n) => n.id);
         setSelected(newSelected);
         return;
       }
@@ -411,34 +404,20 @@ const PublicPlanListPage: React.FC<IPlansListProps> = (props) => {
                       />
                     </TableCell>
                     <TableCell padding="checkbox">
-                      {row.export ? (
-                        <Tooltip
-                          title={
-                            isItemSelected ? TableI18N.exportSelected : TableI18N.exportNotSelected
-                          }
-                          placement="top">
-                          <Checkbox
-                            color="primary"
-                            checked={isItemSelected}
-                            inputProps={{
-                              'aria-labelledby': labelId
-                            }}
-                            onClick={(event) => handleClick(event, row.id)}
-                          />
-                        </Tooltip>
-                      ) : (
-                        <Tooltip title={TableI18N.noDataToExport} placement="top">
-                          <span>
-                            <Checkbox
-                              disabled={true}
-                              color="primary"
-                              inputProps={{
-                                'aria-labelledby': labelId
-                              }}
-                            />
-                          </span>
-                        </Tooltip>
-                      )}
+                      <Tooltip
+                        title={
+                          isItemSelected ? TableI18N.exportSelected : TableI18N.exportNotSelected
+                        }
+                        placement="top">
+                        <Checkbox
+                          color="primary"
+                          checked={isItemSelected}
+                          inputProps={{
+                            'aria-labelledby': labelId
+                          }}
+                          onClick={(event) => handleClick(event, row.id)}
+                        />
+                      </Tooltip>
                     </TableCell>
                   </TableRow>
                 );

--- a/app/src/utils/pagedProjectPlanTableUtils.ts
+++ b/app/src/utils/pagedProjectPlanTableUtils.ts
@@ -115,7 +115,6 @@ export interface PlanData {
   statusCode: number;
   statusLabel: string;
   archive: string;
-  export: string;
 }
 
 export interface PlansTableProps {


### PR DESCRIPTION
## Links to Jira Tickets

- NERT-663

## Description of Changes

- Public and Auth Plan List view now is not disabling export checkboxes if plan doesn't have a geolocated features. 
- Filtered out archived projects/plans from main map