### PR TITLE
Nert 666c - Dormant Well Layer

### DIFF
--- a/app/src/components/map/MapContainer.tsx
+++ b/app/src/components/map/MapContainer.tsx
@@ -135,7 +135,6 @@ const drawWells = (map: maplibre.Map, wells: any, dormantWells: any, tooltipStat
   // On hover of cluster layer highlight the circle stroke to be yellow
   let hoverStateWellClusterLayer: boolean | any = false;
   map.on('mouseenter', 'dormantWellsClusterLayer', (e: any) => {
-    
     // Clear old hover state if present
     if (hoverStateWellClusterLayer) {
       map.setFeatureState(
@@ -613,7 +612,9 @@ const initializeMap = (
   editModeOn?: boolean,
   region?: string | null
 ) => {
-  const { boundary, orphanedWells, dormantWells, projects, plans, protectedAreas, seismic } = layerVisibility;
+  const { boundary, orphanedWells, projects, plans, protectedAreas, seismic } = layerVisibility;
+
+  const dormantWells = layerVisibility.dormantWells || [];
 
   const { setTooltip, setTooltipVisible, setTooltipX, setTooltipY } = tooltipState;
 

--- a/app/src/components/map/components/LayerSwitcherInline.tsx
+++ b/app/src/components/map/components/LayerSwitcherInline.tsx
@@ -24,6 +24,7 @@ export interface ILayerSwitcherProps {
   layerVisibility: {
     boundary: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
     orphanedWells: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
+    dormantWells: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
     projects: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
     plans: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
     protectedAreas: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
@@ -48,12 +49,16 @@ const iconLegendIconStyle = {
 const LayerSwitcherInline = (props: ILayerSwitcherProps) => {
   const { boundary, orphanedWells, projects, plans, protectedAreas, seismic, baselayer } =
     props.layerVisibility;
+
+  const dormantWells = props.layerVisibility.dormantWells || [];
+
   const basemapChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     baselayer[1](event.target.value);
   };
 
   const boundaryFilter = props.filterState?.boundary;
   const orphanedWellFilter = props.filterState?.orphanedWells;
+  const dormantWellFilter = props.filterState?.dormantWells;
 
   return (
     <div>
@@ -166,10 +171,6 @@ const LayerSwitcherInline = (props: ILayerSwitcherProps) => {
             )}
           </LayerControl>
 
-          {/* <FormControlLabel
-            control={<Checkbox checked={wells[0]} onClick={() => wells[1](!wells[0])} />}
-            label="Wells"
-          /> */}
           <LayerControl
             title="Orphaned Wells"
             subTitle="BC Energy Regulator orphaned wells and orphaned well activities"
@@ -204,6 +205,42 @@ const LayerSwitcherInline = (props: ILayerSwitcherProps) => {
               </List>
             )}
           </LayerControl>
+
+          <LayerControl
+            title="Dormant Wells"
+            subTitle="Wells that are currently inactive"
+            layerState={dormantWells}>
+            {props.legend.dormantWells && (
+              <List dense>
+                {props.legend.dormantWells.map((well: any) => (
+                  <ListItem 
+                    key={well.label}
+                    secondaryAction={
+                      well.allowToggle && (
+                        <Checkbox
+                          edge="end"
+                          checked={dormantWellFilter[well.label][0]}
+                          onClick={() => {
+                            dormantWellFilter[well.label][1](!dormantWellFilter[well.label][0]);
+                          }}
+                        />
+                      )
+                    }>
+                    <ListItemAvatar>
+                      <Avatar
+                        src={well.image}
+                        style={{ backgroundColor: well.color, borderColor: well.outlineColor }}
+                        className={well.outlineColor ? 'outlined' : ''}>
+                        &nbsp;
+                      </Avatar>
+                    </ListItemAvatar>
+                    <ListItemText primary={well.label} />
+                  </ListItem>
+                ))}
+              </List>
+            )}
+          </LayerControl>
+          
 
           <FormControlLabel
             control={<Checkbox checked={seismic[0]} onClick={() => seismic[1](!seismic[0])} />}

--- a/app/src/components/map/components/LayerSwitcherInline.tsx
+++ b/app/src/components/map/components/LayerSwitcherInline.tsx
@@ -213,7 +213,7 @@ const LayerSwitcherInline = (props: ILayerSwitcherProps) => {
             {props.legend.dormantWells && (
               <List dense>
                 {props.legend.dormantWells.map((well: any) => (
-                  <ListItem 
+                  <ListItem
                     key={well.label}
                     secondaryAction={
                       well.allowToggle && (
@@ -240,7 +240,6 @@ const LayerSwitcherInline = (props: ILayerSwitcherProps) => {
               </List>
             )}
           </LayerControl>
-          
 
           <FormControlLabel
             control={<Checkbox checked={seismic[0]} onClick={() => seismic[1](!seismic[0])} />}

--- a/app/src/features/search/SearchPage.tsx
+++ b/app/src/features/search/SearchPage.tsx
@@ -287,7 +287,7 @@ const SearchPage: React.FC = () => {
 
   const filterState = {
     boundary: boundaryState,
-    orphanedWells: orphanedWellsState,
+    orphanedWells: orphanedWellsState
   };
 
   const sidebarButtonStyle = {

--- a/app/src/features/search/SearchPage.tsx
+++ b/app/src/features/search/SearchPage.tsx
@@ -98,6 +98,7 @@ const SearchPage: React.FC = () => {
    */
   const boundary = useState<boolean>(true);
   const orphanedWells = useState<boolean>(false);
+  const dormantWells = useState<boolean>(false);
   const projects = useState<boolean>(true);
   const plans = useState<boolean>(true);
   const protectedAreas = useState<boolean>(false);
@@ -107,6 +108,7 @@ const SearchPage: React.FC = () => {
   const layerVisibility = {
     boundary,
     orphanedWells,
+    dormantWells,
     projects,
     plans,
     protectedAreas,
@@ -236,6 +238,22 @@ const SearchPage: React.FC = () => {
         outlineColor: '#4a72b5',
         color: '#ffffff'
       }
+    ],
+    dormantWells: [
+      {
+        label: 'Multiple Wells',
+        visible: true,
+        allowToggle: false,
+        color: 'rgba(50,145,168,0.5)',
+        outlineColor: 'white'
+      },
+      {
+        label: 'Single Well',
+        visible: true,
+        allowToggle: false,
+        color: 'rgba(255,153,0,0.8)',
+        outlineColor: 'white'
+      }
     ]
   };
 
@@ -269,7 +287,7 @@ const SearchPage: React.FC = () => {
 
   const filterState = {
     boundary: boundaryState,
-    orphanedWells: orphanedWellsState
+    orphanedWells: orphanedWellsState,
   };
 
   const sidebarButtonStyle = {


### PR DESCRIPTION
- New Dormant Well Layer
- Made to match [official custodian map](https://geoweb-ags.bc-er.ca/portal/apps/webappviewer/index.html?id=b8a2b40512a8493284fc3c322077e677&mobileBreakPoint=300)
- Clustering used down to zoom level 12
- Hovering over cluster hints that the user can interact with it
- Clicking the cluster zooms the user in until at least one feature is released from the cluster
- Hover effect with tooltip on single wells
- Clicking a single well opens a popup with more information
- Legend only, as the BCER site does not separate dormant symbols on the map.

![Screenshot from 2024-09-25 15-05-41](https://github.com/user-attachments/assets/df97a8ee-89b1-4c10-8b4f-6a7498c8b4ad)
![Screenshot from 2024-09-25 15-06-12](https://github.com/user-attachments/assets/67589622-b161-43d8-981b-960ff914ab6b)
![Screenshot from 2024-09-25 15-06-27](https://github.com/user-attachments/assets/88fff8e3-5841-4dad-b927-55c41ef891ae)
![Screenshot from 2024-09-25 15-06-47](https://github.com/user-attachments/assets/09415f00-6fae-4cd3-9f47-d416f7ee377e)
![Screenshot from 2024-09-25 15-05-29](https://github.com/user-attachments/assets/000f2f75-7a0e-430b-b56c-38606c88d45b)
