### PR TITLE
NERT-653a reversed pipeline change, updated env label in header

### DIFF
--- a/app/.pipeline/config.js
+++ b/app/.pipeline/config.js
@@ -114,7 +114,7 @@ const phases = {
     objectStorageBucket: config.objectStorageBucket.test,
     maxUploadNumFiles,
     maxUploadFileSize,
-    nodeEnv: 'test',
+    nodeEnv: 'production',
     mapTiler: config.mapTiler.test,
     sso: config.sso.test,
     cpuRequest: '50m',

--- a/app/src/components/layout/Header.tsx
+++ b/app/src/components/layout/Header.tsx
@@ -128,7 +128,15 @@ const Header: React.FC = () => {
   const nert_version = versionSplit
     ? versionSplit.split('(')[0] + '.' + config?.CHANGE_VERSION
     : '0.0.0.NA';
-  const nert_environment = config?.REACT_APP_NODE_ENV || 'undefined';
+  const envSplit = config?.VERSION.split('-')[0];
+  const nert_environment =
+    'prod' === envSplit
+      ? 'Production'
+      : 'test' === envSplit
+        ? 'Test'
+        : 'dev' === envSplit
+          ? 'Development'
+          : 'Local';
 
   const authStateContext = useAuthStateContext();
   const identitySource = authStateContext.nertUserWrapper.identitySource || '';


### PR DESCRIPTION
## Links to Jira Tickets

- NERT-653

## Description of Changes

- Test env is treated as Prod, reversed the tag change in pipeline
- The right env label should be showing now across all environments